### PR TITLE
Fixed panic in `Mempool::push_transaction` and head hash update in `Blockchain::rebranch`

### DIFF
--- a/blockchain/src/blockchain/mod.rs
+++ b/blockchain/src/blockchain/mod.rs
@@ -466,6 +466,7 @@ impl<'env> Blockchain<'env> {
             }
 
             // Commit transaction & update head.
+            self.chain_store.set_head(&mut write_txn, &fork_chain[0].0);
             write_txn.commit();
             state.transaction_cache = cache_txn;
 

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -207,10 +207,12 @@ impl<'env> Mempool<'env> {
                 if transaction.cmp(tx) == Ordering::Greater {
                     break;
                 }
-
-                sender_account = sender_account
-                    .with_outgoing_transaction(tx, block_height)
-                    .expect("Failed to apply existing transaction");
+                // Reject the transaction, if after the intrinsic check, the balance went too low
+                sender_account = match sender_account
+                    .with_outgoing_transaction(tx, block_height) {
+                    Ok(s) => s,
+                    Err(_) => return ReturnCode::Invalid
+                };
                 tx_count += 1;
 
                 tx_opt = tx_iter.next_back();


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

On block 488308 a fork happened that was resolved at block 488309. After rebranching a transaction was pushed to the mempool which crashed the node. Somehow the sender balance was out of funds. It is possible for a transaction to be verified, but later when all transactions for the sender address are being rechecked, that the sender is out of funds. It is unclear if this caused the crash. The log looks like the transaction was received after the block was processed, but maybe the other transactions with the same sender address weren't removed from the mempool yet. I will check this later. I fixed this, by rejecting a transaction during rechecking if the sender is out of funds, as this should be the intended behavior. Another possible fix is to synchronize the whole `Mempool::push_transaction` over the `Blockchain` or `Accounts`.

After the crash the node didn't restart, because the rebranching code didn't update the head hash in the `ChainStore`, which caused the head's accounts tree hash to be incorrect. I fixed this by updating the `ChainStore`'s head hash before commiting the rebranching transaction. 