### PR TITLE
Synchronize mempool and blockchain

### DIFF
--- a/blockchain/src/blockchain/mod.rs
+++ b/blockchain/src/blockchain/mod.rs
@@ -36,7 +36,7 @@ pub struct Blockchain<'env> {
     pub notifier: RwLock<Notifier<'env, BlockchainEvent>>,
     pub(crate) chain_store: ChainStore<'env>,
     pub(crate) state: RwLock<BlockchainState<'env>>,
-    push_lock: Mutex<()>,
+    pub push_lock: Mutex<()>, // TODO: Not very nice to have this public
 
     #[cfg(feature = "metrics")]
     pub metrics: BlockchainMetrics,


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

#### This fixes issue #___.

## What's in this pull request?

As discussed with Philipp, this synchronizes the state of the blockchain (i.e. accounts) with the Mempool. In my opinion we can't lock less than this. We also considered using a priority lock to prioritize `Blockchain::push`