### PR TITLE
Readme: update example.toml link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can also specify your own configuration file:
 nimiq-client -c path/to/client.toml
 ```
 
-Take a look at [`client/client.example.toml`](client/config.example.toml) for all the configuration options.
+Take a look at [`client/client.example.toml`](client/client.example.toml) for all the configuration options.
 
 ### From crates.io
 


### PR DESCRIPTION
Text was correct but underlying link did not point to the correct file.

