### PR TITLE
Add minimum RAM to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Nimiq Rust client comes without wallet and can currently not be used to send
 
 ## Install
 
-Besides [Rust nightly](https://www.rust-lang.org/learn/get-started#installing-rust) itself, the following packages are required to be able to compile this source code:
+Around 2GB of RAM is needed to compile. Besides [Rust nightly](https://www.rust-lang.org/learn/get-started#installing-rust) itself, the following packages are required to be able to compile this source code:
 
 - `gcc`
 - `pkg-config`


### PR DESCRIPTION
## Pull request checklist

- (n/a) All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?
Adds that one needs 2GB of RAM to build. I tried to build this with 1GB of RAM, and it didn't work until I went up to 2GB.
